### PR TITLE
If -u or -U specified, do not upgrade OS.

### DIFF
--- a/snap
+++ b/snap
@@ -32,7 +32,7 @@ snap options:
   -a <arch> use <arch> instead of what is 'arch' returns.
   -m <machine> use <machine> instead of what 'machine' returns.
   -v <version> used to force snap to use <version> (examples: snapshots or 5.3).
-  -V <setversion> used to force snap to use <setversion> for sets (example: -V 5.3). Note: this will only apend 53 to sets, ie base53.tgz.
+  -V <setversion> used to force snap to use <setversion> for sets (example: -V 5.3). Note: this will only append 53 to sets, ie base53.tgz.
   -r run sysmerge after extracting {x}sets.
   -x do not extract x11 sets.
   -M specify a mirror to use (example: " -M ftp3.usa.openbsd.org")
@@ -311,6 +311,7 @@ done
 
 if [ $CHK_UPDATE == true ]; then
     check_update
+    exit 0
 fi
 
 [[ $(id -u) -ne 0 ]] && error "${sname}: need root privileges"


### PR DESCRIPTION
When I invoked 'snap -u' I was surprised to see my OS upgraded as well. I think the argument could be made that if the user is testing for an update to the snap utility itself (or, using -U to update the utility), the user does not expect their operating system to be updated as well. This matches the behavior of the -h flag which exits after printing help output.
