### PR TITLE
Update snap version to match release version 1.0.6

### DIFF
--- a/snap
+++ b/snap
@@ -1,6 +1,6 @@
 #!/bin/ksh
 
-version=1.0.5
+version=1.0.6
 
 grey="\033[01;30m"
 red="\033[01;31m"


### PR DESCRIPTION
- LolingLteo is version 1.0.6 but internally snap has version set to 1.0.5.