### PR TITLE
snap: -U argument implies -u.

### DIFF
--- a/snap
+++ b/snap
@@ -303,6 +303,7 @@ while getopts "sSfea:sm:sv:srV:spxR:sAM:shiBknuUb" arg; do
 	    CHK_UPDATE=true
 	    ;;
 	U)
+	    CHK_UPDATE=true
 	    INS_UPDATE=true
 	    ;;
 	b)


### PR DESCRIPTION
- Currently, in order to cause snap to upgrade itself, one must use
  `./snap -uU`. Further, the current behavior of specifying -U without -u is
  unexpected: no snap upgrade checks are performed and the running OS itself
  is upgraded.

  This diff changes the behavior of specifying -U in isolation such that
  snap both checks for an upgrade to itself and performs the upgrade if one
  exists. From testing, there is no pathological change to specifying -u in
  isolation or -uU together.