### PR TITLE
Various improvements (2)

### DIFF
--- a/snap
+++ b/snap
@@ -79,14 +79,6 @@ function get_conf_var {
     fi
 }
 
-
-function mkd {
-    if [ ! -e $1 ]; then
-	msg "mkdir: ${1}"
-	mkdir -p $1
-    fi
-}
-
 function msg {
     if [ $INTERACTIVE == true ]; then
 	echo "${green}${1}${white}"
@@ -321,7 +313,7 @@ if [ $? == 0 ]; then
     VER='snapshots'
 fi
 
-mkd $DST
+mkdir -p -- "$DST" || exit 1
 
 URL="http://${MIRROR}/pub/OpenBSD/${VER}/${MACHINE}"
 

--- a/snap
+++ b/snap
@@ -193,28 +193,12 @@ function update_kernel {
 
 function fetch {
     /usr/bin/ftp $FTP_OPTS $1
-    if [ $? == 0 ]; then
-	return 0
-    else
-	return $?
-    fi
+    return $?
 }
 
 function extract {
-    FAIL=0
-    ftp -D Extracting -Vmo - file://${1} | tar -C / -xzphf - || FAIL=1
-
-    if [ $FAIL == 1 ]; then
-	error "Extract of ${1} failed, permissions?"
-    fi
-}
-
-function copy {
-    FAIL=0
-    cp $1 $2 || FAIL=1
-    if [ $FAIL == 1 ]; then
-	error "Can't copy ${1} to ${2}"
-    fi
+    ftp -D Extracting -Vmo - file://${1} | tar -C / -xzphf - \
+		|| error "Failed to extract ${1}"
 }
 
 CONF_FILE=~/.snaprc
@@ -297,6 +281,8 @@ while getopts "sSfesm:sv:srV:spxR:sAM:shiBknuUb" arg; do
 	R)
 	    REBOOT=$(echo $OPTARG)
 	    ;;
+	*)
+	    exit 1
     esac
 done
 
@@ -324,7 +310,7 @@ URL="http://${MIRROR}/pub/OpenBSD/${VER}/${MACHINE}"
 msg "${white}Fetching from: ${green}${URL}"
 
 (
-    cd $DST
+    cd -- "$DST" || exit 1
 
     # first element should be bsd, second should be mp for given kernel names.
     if [ "${MACHINE}" == "armv7" ]; then

--- a/snap
+++ b/snap
@@ -86,12 +86,16 @@ function msg {
 }
 
 function error {
-    if [ $INTERACTIVE == true ]; then
+    if [[ $INTERACTIVE == true ]]; then
 	echo "${red}${1}${white}"
+    else
+	echo "$1"
     fi
-    if [ $2 ] && [ $2 == true ]; then
+
+    if [[ $2 == true ]]; then
 	rollback
     fi
+
     exit 1
 }
 


### PR DESCRIPTION
Hi,

All the info should be in the commit messages.
If you're wondering about the use of `[[ expression ]]`, here's a snippet from the ksh(1) man page:
```
     [[ expression ]]
             Similar to the test and [ ... ] commands (described later), with
             the following exceptions:

                   •   Field splitting and file name generation are not
                       performed on arguments.
                   •   The -a (AND) and -o (OR) operators are replaced with
                       ‘&&’ and ‘||’, respectively.

                   •   Operators (e.g. ‘-f’, ‘=’, ‘!’) must be unquoted.

                   •   The second operand of the ‘!=’ and ‘=’ expressions are
                       patterns (e.g. the comparison [[ foobar = f*r ]]
                       succeeds).
                   •   There are two additional binary operators, ‘<’ and ‘>’,
                       which return true if their first string operand is less
                       than, or greater than, their second string operand,
                       respectively.

                   •   The single argument form of test, which tests if the
                       argument has a non-zero length, is not valid; explicit
                       operators must always be used e.g. instead of [ str ]
                       use [[ -n str ]].

                   •   Parameter, command, and arithmetic substitutions are
                       performed as expressions are evaluated and lazy
                       expression evaluation is used for the ‘&&’ and ‘||’
                       operators.  This means that in the following statement,
                       $(< foo) is evaluated if and only if the file foo
                       exists and is readable:
                             $ [[ -r foo && $(< foo) = b*r ]]

```