### PR TITLE
Makefile: Add (un)install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
 VERSION=`awk -F= '/^version/ {print $2}' snap | cut -d= -f2`
 
+PREFIX ?= /usr/local
+
 help:
 	@awk 'BEGIN{print "Usage\n====="} /^  -/ {print "*"$$0}' ./snap
-	@echo 
+	@echo
 	@awk 'BEGIN{print ".snaprc options and defaults\n======="} /\(get_conf_var/ {gsub("\x27|\\)", "", $$0); print "* **"$$2"**: " "*"$$5"*"}' ./snap
- 
+
 release:
 	@git tag $(VERSION)
 	@git push --tags
+
+install:
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m 755 snap $(DESTDIR)$(PREFIX)/bin/snap
+
+uninstall:
+	rm -f $(DESTDIR)$(PREFIX)/bin/snap

--- a/README.md
+++ b/README.md
@@ -19,9 +19,8 @@ Features
 Installation
 ============
 
-``` sh
-ftp https://raw.github.com/qbit/snap/master/snap
-sudo install -m 755 snap /usr/local/bin
+```
+# make install
 ```
 
 Usage


### PR DESCRIPTION
I figure we're already using a Makefile, so we might as well add these targets given people might expect them to be present.