### PR TITLE
Backups should run by default and -B should suppress them

### DIFF
--- a/snap
+++ b/snap
@@ -476,7 +476,7 @@ fi
                 KERNEL=${bsds[1]}
             fi
 
-            if [ "${NO_KBACKUPS:=false}" == true ]; then
+            if [ "${NO_KBACKUPS:=false}" == false ]; then
                 if [ $DOWNLOAD_ONLY == false ]; then
                     backup
                 fi


### PR DESCRIPTION
Took me this long to realize backups of /bsd, /bsd.sp and /sbin/reboot weren't happening by default anymore. According to docs, -B should suppress backups not enable them.