### PR TITLE
Allow self doas prompt

### DIFF
--- a/snap
+++ b/snap
@@ -418,7 +418,19 @@ if [ $CHK_UPDATE == true ]; then
     exit 0
 fi
 
-[[ $(id -u) -ne 0 ]] && error "need root privileges" false
+UID=$(id -u)
+grep -q $(echo $LOGNAME) /etc/doas.conf
+UFOUND=$?
+
+PID=$$
+PROC=$(ps -o args -p ${PID} | sed 1d)
+
+if [ ${UID} -ne 0 ] && [ ${UFOUND} -eq 0 ]; then
+    doas ${PROC}
+    exit 0
+elif [[ ${UID} -ne 0 ]]; then
+    error "need root privileges"
+fi
 
 mkdir -p -- "$DST" || exit 1
 


### PR DESCRIPTION
A bit of a rough attempt so hoping for input and suggestions to improve.

This change allows snap to prompt for doas if the user forgets it but may be able to run the script. If this succeeds it calls itself again with doas. I am not too sure how to kill the original PID and switch to the new one but this did not seem to cause problems during my tests. 

If the user is not found in doas.conf display the original error message indicating root is required to run the script.