### PR TITLE
Add CLEAN_ONLY flag

### DIFF
--- a/snap
+++ b/snap
@@ -329,7 +329,7 @@ MIRROR=$(get_conf_var 'MIRROR' || \
 	awk -F/ 'match($3, /[a-z]/) {print $3}' /etc/installurl 2> /dev/null || \
 	echo "cdn.openbsd.org")
 
-while getopts "Cb:Bc:dD:ehiIkKm:M:nrRsSuUV:Wx" arg; do
+while getopts "b:BCc:dD:ehiIkKm:M:nrRsSuUV:Wx" arg; do
 	case $arg in
 		b)
 			INSTBOOT=$OPTARG

--- a/snap
+++ b/snap
@@ -30,6 +30,7 @@ snap options:
 
   -s force snap to use snapshots.
   -S do not check signatures.
+  -C only remove partial downloads.
   -c specify location of config file (default is ~/.snaprc)
   -e just extract sets in DST.
   -d just download sets to DST, verify and exit.
@@ -322,18 +323,21 @@ REBOOT=$(get_conf_var 'REBOOT' || echo 'false')
 AFTER=$(get_conf_var 'AFTER' || echo 'false')
 DOWNLOAD_ONLY=false
 WEXIT=$(get_conf_var 'WEXIT' || echo 'false')
+CLEAN_ONLY=false
 
 MIRROR=$(get_conf_var 'MIRROR' || \
 	awk -F/ 'match($3, /[a-z]/) {print $3}' /etc/installurl 2> /dev/null || \
 	echo "cdn.openbsd.org")
 
-while getopts "b:Bc:dD:ehiIkKm:M:nrRsSuUV:Wx" arg; do
+while getopts "Cb:Bc:dD:ehiIkKm:M:nrRsSuUV:Wx" arg; do
 	case $arg in
 		b)
 			INSTBOOT=$OPTARG
 			;;
 		B)
 			NO_KBACKUPS=true
+			;;
+		C)	CLEAN_ONLY=true
 			;;
 		c)
 			CONF_FILE=$OPTARG
@@ -407,6 +411,14 @@ while getopts "b:Bc:dD:ehiIkKm:M:nrRsSuUV:Wx" arg; do
 			exit 1
 	esac
 done
+
+if [ $CLEAN_ONLY == true ]; then
+	if [ $DST ]; then
+		rm -rf $DST/snap.*
+	else
+		rm -rf /tmp/snap.*
+	exit 0
+fi
 
 if [ $KERNEL_ONLY == true ] && [ $SETS_ONLY == true ]; then
 	echo 'The options -k and -K are mutually exclusive.'


### PR DESCRIPTION
When in an environment where there may be connectivity issues /tmp will be potentially filled by broken downloads. This happens as mktemp create new randomly named directories each time the script is run.

I know @qbit has issue #48 to remove some options but I felt this useful to add. I am not familiar with man page syntax so I did not add it there.

Thoughts? Perhaps it may be better to add cleaning of snap downloads in $DST or /tmp as the first step each time the script is run instead.